### PR TITLE
Add mobile-friendly improvements

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/png" href="/favicon.png" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta name="description" content="MogTome - Your cozy FFXIV Free Company hub" />
     <meta name="theme-color" content="#B794C7" />
     <title>MogTome</title>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -63,7 +63,7 @@ function ThemeToggleButton() {
   return (
     <motion.button
       onClick={() => setIsDark((prev) => !prev)}
-      className="relative w-9 h-9 rounded-xl bg-[var(--bento-card)]/80 border border-[var(--bento-primary)]/15 cursor-pointer shadow-sm"
+      className="relative w-10 h-10 md:w-9 md:h-9 rounded-xl bg-[var(--bento-card)]/80 border border-[var(--bento-primary)]/15 cursor-pointer shadow-sm"
       style={{ perspective: 600 }}
       aria-label="Toggle theme"
       whileHover={{ scale: 1.1, rotate: 5 }}
@@ -71,7 +71,7 @@ function ThemeToggleButton() {
     >
       {/* The flipper */}
       <motion.div
-        className="absolute inset-1 rounded-lg"
+        className="absolute inset-1.5 md:inset-1 rounded-lg"
         style={{ transformStyle: "preserve-3d" }}
         animate={{ rotateY: isDark ? 180 : 0 }}
         transition={{ type: "spring", stiffness: 800, damping: 30 }}
@@ -361,9 +361,9 @@ export function Navbar() {
   const isActive = (path: string) => location.pathname === path;
 
   return (
-    <nav className="sticky top-0 z-50 transition-all duration-300">
-      {/* Storybook-style backdrop with warmth */}
-      <div className="absolute inset-0 bg-[var(--bento-card)]/90 backdrop-blur-xl" />
+    <nav className="sticky top-0 z-50 transition-all duration-300" style={{ paddingTop: 'var(--safe-area-inset-top)' }}>
+      {/* Storybook-style backdrop with warmth - extends to cover safe area */}
+      <div className="absolute inset-0 bg-[var(--bento-card)]/90 backdrop-blur-xl" style={{ top: 'calc(-1 * var(--safe-area-inset-top))' }} />
       <div className="absolute inset-0 bg-gradient-to-r from-[var(--bento-primary)]/[0.03] via-[var(--bento-accent)]/[0.02] to-[var(--bento-secondary)]/[0.03] pointer-events-none" />
       
       {/* Floating whimsical sparkles */}
@@ -375,7 +375,7 @@ export function Navbar() {
       {/* Bottom border with storybook style */}
       <div className="absolute bottom-0 left-0 right-0 h-px bg-gradient-to-r from-transparent via-[var(--bento-primary)]/25 to-transparent" />
       
-      <div className="relative max-w-7xl mx-auto px-4 md:px-6 lg:px-8">
+      <div className="relative max-w-7xl mx-auto px-4 md:px-6 lg:px-8" style={{ paddingLeft: 'max(1rem, var(--safe-area-inset-left, 0px))', paddingRight: 'max(1rem, var(--safe-area-inset-right, 0px))' }}>
         <div className="flex items-center justify-between h-[4.5rem]">
           {/* Brand mark */}
           <Link 
@@ -490,12 +490,14 @@ export function Navbar() {
             <KupoBadge />
             <ThemeToggleButton />
 
-            {/* Mobile menu button */}
+            {/* Mobile menu button - min 44px touch target */}
             <motion.button
               onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
-              className="md:hidden relative p-2.5 rounded-xl text-[var(--bento-text-muted)] hover:text-[var(--bento-primary)] bg-[var(--bento-card)]/80 border border-[var(--bento-primary)]/10 transition-colors"
+              className="md:hidden relative p-3 rounded-xl text-[var(--bento-text-muted)] hover:text-[var(--bento-primary)] bg-[var(--bento-card)]/80 border border-[var(--bento-primary)]/10 transition-colors"
               whileHover={{ scale: 1.05 }}
               whileTap={{ scale: 0.95 }}
+              aria-label={mobileMenuOpen ? "Close menu" : "Open menu"}
+              aria-expanded={mobileMenuOpen}
             >
               <AnimatePresence mode="wait" initial={false}>
                 {mobileMenuOpen ? (

--- a/src/index.css
+++ b/src/index.css
@@ -8,19 +8,77 @@
 @layer base {
   html {
     scroll-behavior: smooth;
+    /* Fix for mobile viewport height (accounts for browser chrome) */
+    height: -webkit-fill-available;
   }
   
   body {
     font-family: 'Nunito', 'Inter', system-ui, sans-serif;
     min-height: 100vh;
+    min-height: -webkit-fill-available;
     margin: 0;
     -webkit-font-smoothing: antialiased;
+    /* Prevent horizontal overflow on mobile */
+    overflow-x: hidden;
+    /* Enable smooth scrolling on iOS */
+    -webkit-overflow-scrolling: touch;
+  }
+
+  /* Root element fills viewport properly on mobile */
+  #root {
+    min-height: 100vh;
+    min-height: -webkit-fill-available;
   }
   
   h1, h2, h3, h4, h5, h6 {
     font-family: 'Fredoka', 'Nunito', system-ui, sans-serif;
     font-weight: 600;
     color: var(--bento-text);
+  }
+
+  /* Prevent iOS Safari zoom on input focus (requires font-size >= 16px) */
+  @media screen and (max-width: 768px) {
+    input, select, textarea {
+      font-size: 16px !important;
+    }
+  }
+
+  /* Improve touch targets - minimum 44x44px for accessibility */
+  @media (pointer: coarse) {
+    button, 
+    a, 
+    [role="button"],
+    input[type="checkbox"],
+    input[type="radio"] {
+      min-height: 44px;
+      min-width: 44px;
+    }
+    
+    /* Allow smaller inline buttons/links that are part of text */
+    .inline, p a, span a {
+      min-height: auto;
+      min-width: auto;
+    }
+  }
+
+  /* Better touch feedback */
+  @media (hover: none) {
+    button:active,
+    a:active,
+    [role="button"]:active {
+      opacity: 0.8;
+    }
+  }
+
+  /* Remove tap highlight on mobile */
+  * {
+    -webkit-tap-highlight-color: transparent;
+  }
+
+  /* Prevent text selection on interactive elements for better UX */
+  button, a, [role="button"] {
+    -webkit-user-select: none;
+    user-select: none;
   }
 }
 
@@ -64,6 +122,14 @@
 .font-accent { font-family: 'Caveat', cursive; }
 .font-soft { font-family: 'Nunito', system-ui, sans-serif; }
 .font-title { font-family: 'Fredoka', 'Nunito', system-ui, sans-serif; }
+
+/* Safe area insets for notched devices (iPhone X+, etc.) */
+:root {
+  --safe-area-inset-top: env(safe-area-inset-top, 0px);
+  --safe-area-inset-right: env(safe-area-inset-right, 0px);
+  --safe-area-inset-bottom: env(safe-area-inset-bottom, 0px);
+  --safe-area-inset-left: env(safe-area-inset-left, 0px);
+}
 
 /* Background - Pom-Pom Classic (Richer) */
 .bento-bg-mesh {

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -272,8 +272,8 @@ export function Home() {
                 animate={{ opacity: 1, scale: 1 }}
                 transition={{ duration: 0.6, delay: 0.4 }}
               >
-                {/* Speech bubble - fixed size to prevent jumping */}
-                <div className="relative bg-[var(--bento-card)] rounded-2xl px-6 py-4 shadow-lg border border-[var(--bento-primary)]/15 w-[300px] md:w-[360px] h-[70px] md:h-[80px] flex items-center justify-center mx-auto">
+                {/* Speech bubble - responsive sizing */}
+                <div className="relative bg-[var(--bento-card)] rounded-2xl px-4 sm:px-6 py-4 shadow-lg border border-[var(--bento-primary)]/15 w-[calc(100vw-4rem)] max-w-[300px] sm:max-w-[360px] min-h-[70px] sm:min-h-[80px] flex items-center justify-center mx-auto">
                   {/* Bubble tail pointing up - bigger and more prominent */}
                   <div className="absolute -top-5 left-1/2 -translate-x-1/2">
                     <div className="w-0 h-0 border-l-[18px] border-l-transparent border-r-[18px] border-r-transparent border-b-[22px] border-b-[var(--bento-card)]" />
@@ -350,7 +350,7 @@ export function Home() {
       </section>
 
       {/* Footer - storybook closing */}
-      <footer className="py-8 px-4 relative z-10">
+      <footer className="py-8 px-4 relative z-10" style={{ paddingBottom: 'calc(2rem + var(--safe-area-inset-bottom, 0px))' }}>
         <motion.div 
           className="max-w-md mx-auto text-center"
           initial={{ opacity: 0 }}

--- a/src/pages/Members.tsx
+++ b/src/pages/Members.tsx
@@ -273,7 +273,8 @@ export function Members() {
           {/* Sticky search bar - storybook styled */}
           <div 
             ref={searchContainerRef}
-            className={`sticky top-[5rem] z-30 mb-8 pt-2 transition-[margin] duration-200 ${isCompact ? 'mx-4 md:mx-8' : ''}`}
+            className={`sticky z-30 mb-8 pt-2 transition-[margin] duration-200 ${isCompact ? 'mx-4 md:mx-8' : ''}`}
+            style={{ top: 'calc(4.5rem + var(--safe-area-inset-top, 0px))' }}
           >
                 <div 
                   className={`
@@ -388,21 +389,24 @@ export function Members() {
                   )}
                 </div>
                 
-                {/* Back to top button */}
-                <button
-                  onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
-                  className={`
-                    flex-shrink-0 p-2 rounded-xl
-                    bg-[var(--bento-bg)] 
-                    hover:bg-[var(--bento-primary)]/10 
-                    text-[var(--bento-text-muted)] hover:text-[var(--bento-primary)] 
-                    cursor-pointer transition-all duration-200 ease-out
-                    ${isCompact ? 'opacity-100' : 'opacity-0 w-0 p-0 overflow-hidden'}
-                  `}
-                  title="Back to top"
-                >
-                  <ChevronDown className="w-4 h-4 rotate-180" />
-                </button>
+                {/* Back to top button - only shows when scrolled down (compact mode) */}
+                {isCompact && (
+                  <button
+                    onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
+                    className="
+                      flex-shrink-0 w-9 h-9 rounded-xl
+                      flex items-center justify-center
+                      bg-[var(--bento-bg)] 
+                      hover:bg-[var(--bento-primary)]/10 
+                      text-[var(--bento-text-muted)] hover:text-[var(--bento-primary)] 
+                      cursor-pointer transition-colors duration-200
+                    "
+                    title="Back to top"
+                    aria-label="Scroll to top"
+                  >
+                    <ChevronDown className="w-4 h-4 rotate-180" />
+                  </button>
+                )}
                 
                 {/* Refresh button - hidden on mobile */}
                 <motion.button
@@ -655,7 +659,7 @@ export function Members() {
 
           {/* Footer - storybook style */}
           {!isLoading && !isError && filteredMembers.length > 0 && (
-            <footer className="text-center mt-16 pt-8">
+            <footer className="text-center mt-16 pt-8" style={{ paddingBottom: 'calc(2rem + var(--safe-area-inset-bottom, 0px))' }}>
               <StoryDivider className="mx-auto mb-6" />
               <p className="font-accent text-xl text-[var(--bento-text-muted)] flex items-center justify-center gap-2">
                 <Heart className="w-5 h-5 text-[var(--bento-primary)] fill-[var(--bento-primary)]" />


### PR DESCRIPTION
- Prevent iOS Safari zoom on input focus (16px min font size)
- Add safe area insets for notched devices (iPhone X+)
- Fix viewport height for mobile browsers (-webkit-fill-available)
- Improve touch targets (44px minimum for touch devices)
- Add smooth scrolling and better touch feedback
- Make speech bubble responsive on small screens
- Fix sticky search bar positioning with safe area
- Center back-to-top button icon properly
- Add aria labels for accessibility